### PR TITLE
feat: добавил возможность пробрасывать докер образ сверху

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.12.8-alpine3.20
+ARG PYTHON_IMAGE_VERSION=python:3.12.8-alpine3.20
+
+FROM ${PYTHON_IMAGE_VERSION}
 LABEL description="Deflakyzavr (https://github.com/Legion18z/deflakyzavr) plugin."
 
 WORKDIR /deflakyzavr


### PR DESCRIPTION
добавил возможность пробрасывать образ сверху при сборке. 

`docker build -t my-img-tag -f docker/Dockerfile --build-arg PYTHON_IMAGE_VERSION=python:3.12.8-alpine3.20 .`